### PR TITLE
Release 1.7.1 (#268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Changed
+- Ignore package versions which were retracted from pub.dev (#262)
+
+### Fixed
+- Fix exception when including a package which is not published on pub.dev (#260)
+- Fix exception when Pub API could not be reached (#261)
+
 ## 1.7.0 - 2023-09-17
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = de.mariushoefler.flutter_enhancement_suite
 pluginName = Flutter Enhancement Suite
-pluginVersion = 1.7.0
+pluginVersion = 1.7.1
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/kotlin/de/mariushoefler/flutterenhancementsuite/completion/FlutterIconCompletionContributor.kt
+++ b/src/main/kotlin/de/mariushoefler/flutterenhancementsuite/completion/FlutterIconCompletionContributor.kt
@@ -8,7 +8,6 @@ import de.mariushoefler.flutterenhancementsuite.editor.icons.FontAwesomeIcons
 import de.mariushoefler.flutterenhancementsuite.editor.icons.IonIcons
 import de.mariushoefler.flutterenhancementsuite.editor.icons.MaterialCommunityIcons
 import de.mariushoefler.flutterenhancementsuite.editor.icons.MdiIcons
-import org.apache.commons.lang.StringUtils
 import org.dartlang.analysis.server.protocol.CompletionSuggestion
 import javax.swing.Icon
 
@@ -27,7 +26,7 @@ class FlutterIconCompletionContributor : DartCompletionExtension() {
         val element = suggestion.element
         if (element != null) {
             val returnType = element.returnType
-            if (!StringUtils.isEmpty(returnType)) {
+            if (!returnType.isNullOrEmpty()) {
                 element.name?.let { name ->
                     return getIconForDeclaringType(suggestion, name)
                 }

--- a/src/main/kotlin/de/mariushoefler/flutterenhancementsuite/exceptions/PubExceptions.kt
+++ b/src/main/kotlin/de/mariushoefler/flutterenhancementsuite/exceptions/PubExceptions.kt
@@ -8,6 +8,6 @@ class GetLatestPackageVersionException(p: String) :
 class GetCurrentPackageVersionException(p: String) :
     Exception("Cannot read current version number for package: $p")
 
-class PubApiCouldNotBeReached(p: Exception) : Exception("Pub api could not be reached: $p")
+class PubApiCouldNotBeReachedException(p: Exception) : Exception("Pub api could not be reached: $p")
 
-class PubApiUnknownFormat(p: JsonSyntaxException) : Exception("Unexpected response from Pub api: $p")
+class PubApiUnknownFormatException(p: JsonSyntaxException) : Exception("Unexpected response from Pub api: $p")

--- a/src/main/kotlin/de/mariushoefler/flutterenhancementsuite/models/PubPackage.kt
+++ b/src/main/kotlin/de/mariushoefler/flutterenhancementsuite/models/PubPackage.kt
@@ -10,15 +10,16 @@ data class PubPackage(
     fun getLatestVersion(): String? {
         // Check for latest stable release
         val latestVersion = latest.takeUnless { v ->
-            v.version.matches(Regex("^[\\d.]+-.*"))
+            v.version.matches(Regex("^[\\d.]+-.*")) || v.retracted
         } ?: versions.reversed().firstOrNull { v ->
-            !v.version.matches(Regex("^[\\d.]+-.*"))
+            !v.version.matches(Regex("^[\\d.]+-.*")) && !v.retracted
         }
         return latestVersion?.version?.trim()
     }
 
     data class Version(
         val version: String,
+        val retracted: Boolean = false,
         val pubspec: PubspecInfo
     )
 


### PR DESCRIPTION
* Fix exception for non pub.dev packages (#265)

* Fix exception when Pub API could not be reached (#266)

* Ignore package versions which were retracted from pub.dev (#267)

* Remove call to deprecated API